### PR TITLE
Fix invalid date display for due dates

### DIFF
--- a/src/app/(app)/dashboard/admin/page.tsx
+++ b/src/app/(app)/dashboard/admin/page.tsx
@@ -29,6 +29,7 @@ import {
 import { useAuth } from '@/hooks/useAuth';
 import { AssignedIndicator, User, Faculty } from '@/lib/types';
 import { getAllAssignedIndicators, getAllUsers, getAllFaculties } from '@/lib/data';
+import { formatDateSpanish } from '@/lib/dateUtils';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarElement, Title } from 'chart.js';
 import { Pie, Bar } from 'react-chartjs-2';
@@ -234,7 +235,7 @@ export default function AdminDashboard() {
   const generatePDFReport = () => {
     const reportData = {
       title: 'Reporte de Administrador',
-      date: new Date().toLocaleDateString(),
+      date: formatDateSpanish(new Date()),
       stats: {
         total: totalAssignments,
         completed: completedAssignments,
@@ -335,7 +336,7 @@ export default function AdminDashboard() {
   const generateExcelReport = () => {
     const csvContent = [
       ['Reporte de Administrador', ''],
-      ['Fecha', new Date().toLocaleDateString()],
+      ['Fecha', formatDateSpanish(new Date())],
       [''],
       ['Estadísticas Generales'],
       ['Total Asignaciones', totalAssignments],
@@ -368,7 +369,7 @@ export default function AdminDashboard() {
           getStudentName(assignment.userId),
           getFacultyName(assignment.userId),
           statusTranslations[assignment.overallStatus || 'Pending'],
-          new Date(assignment.assignedDate).toLocaleDateString()
+          formatDateSpanish(assignment.assignedDate)
         ])
     ].map(row => row.join(',')).join('\n');
 
@@ -729,7 +730,7 @@ export default function AdminDashboard() {
                               {getStudentName(assignment.userId)}
                             </p>
                             <p className="text-sm text-red-600">
-                              {getFacultyName(assignment.userId)} • Vencida el {assignment.dueDate?.toLocaleDateString()}
+                              {getFacultyName(assignment.userId)} • Vencida el {assignment.dueDate ? formatDateSpanish(assignment.dueDate) : 'Fecha no disponible'}
                             </p>
                           </div>
                         </div>

--- a/src/app/(app)/dashboard/asignador/page.tsx
+++ b/src/app/(app)/dashboard/asignador/page.tsx
@@ -22,6 +22,7 @@ import {
 import { useAuth } from '@/hooks/useAuth';
 import { AssignedIndicator, User, Faculty, ProfessionalSchool, Office, Perspective } from '@/lib/types';
 import { getAllAssignedIndicators, getAllUsers, getAllFaculties, getAllProfessionalSchools, getAllOffices, getAllPerspectives } from '@/lib/data';
+import { formatDateSpanish } from '@/lib/dateUtils';
 
 const statusColors = {
   Pending: 'bg-yellow-100 text-yellow-800',
@@ -117,7 +118,7 @@ export default function AsignadorDashboard() {
       date = new Date(assignment.assignedDate);
     }
     
-    const dateString = date.toLocaleDateString();
+    const dateString = formatDateSpanish(date);
     if (!acc[dateString]) {
       acc[dateString] = [];
     }
@@ -187,15 +188,7 @@ export default function AsignadorDashboard() {
     return names.length ? names.join(', ') : 'Sin jurado asignado';
   };
 
-  const formatDueDate = (dueDate: any) => {
-    if (!dueDate) return 'Sin fecha límite';
-    const date = new Date(dueDate);
-    return date.toLocaleDateString('es-ES', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    });
-  };
+  // Using centralized date utility function
 
   const getLocationInfo = (userId: string) => {
     const facultyName = getFacultyName(userId);
@@ -360,7 +353,7 @@ export default function AsignadorDashboard() {
                             <p><span className="font-medium">Perspectiva:</span> {getPerspectiveName(assignment.perspectiveId)}</p>
                             <p><span className="font-medium">{locationInfo.type}:</span> {locationInfo.value}</p>
                             <p><span className="font-medium">Jurado:</span> {getJuryNames(assignment.jury || [])}</p>
-                            <p><span className="font-medium">Fecha de Vencimiento:</span> {formatDueDate(assignment.dueDate)}</p>
+                            <p><span className="font-medium">Fecha de Vencimiento:</span> {assignment.dueDate ? formatDateSpanish(assignment.dueDate, { year: 'numeric', month: 'long', day: 'numeric' }) : 'Sin fecha límite'}</p>
                           </div>
                         </div>
                         
@@ -426,7 +419,7 @@ export default function AsignadorDashboard() {
                                     <p><span className="font-medium">Perspectiva:</span> {getPerspectiveName(assignment.perspectiveId)}</p>
                                     <p><span className="font-medium">{locationInfo.type}:</span> {locationInfo.value}</p>
                                     <p><span className="font-medium">Jurado:</span> {getJuryNames(assignment.jury || [])}</p>
-                                    <p><span className="font-medium">Fecha de Vencimiento:</span> {formatDueDate(assignment.dueDate)}</p>
+                                    <p><span className="font-medium">Fecha de Vencimiento:</span> {assignment.dueDate ? formatDateSpanish(assignment.dueDate, { year: 'numeric', month: 'long', day: 'numeric' }) : 'Sin fecha límite'}</p>
                                   </div>
                                 </div>
                                 
@@ -487,7 +480,7 @@ export default function AsignadorDashboard() {
                               <p><span className="font-medium">Perspectiva:</span> {getPerspectiveName(assignment.perspectiveId)}</p>
                               <p><span className="font-medium">{locationInfo.type}:</span> {locationInfo.value}</p>
                               <p><span className="font-medium">Jurado:</span> {getJuryNames(assignment.jury || [])}</p>
-                              <p><span className="font-medium">Fecha de Vencimiento:</span> {formatDueDate(assignment.dueDate)}</p>
+                              <p><span className="font-medium">Fecha de Vencimiento:</span> {assignment.dueDate ? formatDateSpanish(assignment.dueDate, { year: 'numeric', month: 'long', day: 'numeric' }) : 'Sin fecha límite'}</p>
                             </div>
                           </div>
                           
@@ -547,7 +540,7 @@ export default function AsignadorDashboard() {
                               <p><span className="font-medium">Perspectiva:</span> {getPerspectiveName(assignment.perspectiveId)}</p>
                               <p><span className="font-medium">{locationInfo.type}:</span> {locationInfo.value}</p>
                               <p><span className="font-medium">Jurado:</span> {getJuryNames(assignment.jury || [])}</p>
-                              <p><span className="font-medium">Fecha de Vencimiento:</span> {formatDueDate(assignment.dueDate)}</p>
+                              <p><span className="font-medium">Fecha de Vencimiento:</span> {assignment.dueDate ? formatDateSpanish(assignment.dueDate, { year: 'numeric', month: 'long', day: 'numeric' }) : 'Sin fecha límite'}</p>
                             </div>
                           </div>
                           

--- a/src/app/(app)/dashboard/calificador/page.tsx
+++ b/src/app/(app)/dashboard/calificador/page.tsx
@@ -23,6 +23,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import { AssignedIndicator, VerificationStatus, User } from '@/lib/types';
 import { getAllAssignedIndicators, getAllUsers } from '@/lib/data';
+import { formatDateSpanish } from '@/lib/dateUtils';
 
 const statusColors = {
   Pending: 'bg-yellow-100 text-yellow-800',
@@ -246,7 +247,7 @@ export default function CalificadorDashboard() {
                               Asignación #{assignment.id} • {getFacultyName(assignment.userId)}
                             </p>
                             <p className="text-xs text-muted-foreground">
-                              Presentado el {new Date().toLocaleDateString()}
+                              Presentado el {formatDateSpanish(new Date())}
                             </p>
                           </div>
                         </div>
@@ -300,7 +301,7 @@ export default function CalificadorDashboard() {
                               {getStudentName(assignment.userId)}
                             </p>
                             <p className="text-sm text-red-600">
-                              Vencida el {assignment.dueDate?.toLocaleDateString()}
+                              Vencida el {assignment.dueDate ? formatDateSpanish(assignment.dueDate) : 'Fecha no disponible'}
                             </p>
                           </div>
                         </div>
@@ -401,7 +402,7 @@ export default function CalificadorDashboard() {
                             Asignación #{assignment.id} • {getFacultyName(assignment.userId)}
                           </p>
                           <p className="text-xs text-muted-foreground">
-                            Asignada el {new Date(assignment.assignedDate).toLocaleDateString()}
+                            Asignada el {formatDateSpanish(assignment.assignedDate)}
                           </p>
                         </div>
                       </div>

--- a/src/app/(app)/dashboard/usuario/page.tsx
+++ b/src/app/(app)/dashboard/usuario/page.tsx
@@ -19,6 +19,7 @@ import {
 import { useAuth } from '@/hooks/useAuth';
 import { AssignedIndicator, VerificationStatus } from '@/lib/types';
 import { getAllAssignedIndicators } from '@/lib/data';
+import { formatDateSpanish } from '@/lib/dateUtils';
 
 const statusColors = {
   Pending: 'bg-yellow-100 text-yellow-800',
@@ -209,7 +210,7 @@ export default function UsuarioDashboard() {
                         <div>
                           <p className="font-medium">Asignación #{assignment.id}</p>
                           <p className="text-sm text-muted-foreground">
-                            Asignada el {new Date(assignment.assignedDate).toLocaleDateString()}
+                            Asignada el {formatDateSpanish(assignment.assignedDate)}
                           </p>
                         </div>
                       </div>
@@ -259,7 +260,7 @@ export default function UsuarioDashboard() {
                           <div>
                             <p className="font-medium">Asignación #{assignment.id}</p>
                             <p className="text-sm text-red-600">
-                              Vencida el {assignment.dueDate?.toLocaleDateString()}
+                              Vencida el {assignment.dueDate ? formatDateSpanish(assignment.dueDate) : 'Fecha no disponible'}
                             </p>
                           </div>
                         </div>

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { saveUploadedFile, sanitizeUserName } from '@/lib/fileUtils';
 import { getCollectionById, updateDocument } from '@/lib/firebase-functions';
 import { getUserById } from '@/lib/data';
+import { safeParseDate } from '@/lib/dateUtils';
 import type { AssignedIndicator, AssignedVerificationMethod, MockFile, VerificationStatus } from '@/lib/types';
 import { Timestamp } from 'firebase/firestore';
 
@@ -52,7 +53,7 @@ export async function POST(request: NextRequest) {
 
     // Verificar si la fecha ha vencido
     const now = new Date();
-    const dueDate = verificationMethod.dueDate ? new Date(verificationMethod.dueDate) : null;
+    const dueDate = verificationMethod.dueDate ? safeParseDate(verificationMethod.dueDate) : null;
     
     if (dueDate && now > dueDate && verificationMethod.status !== 'Approved' && verificationMethod.status !== 'Rejected') {
       return NextResponse.json(
@@ -93,7 +94,7 @@ export async function POST(request: NextRequest) {
       originalName: file.name,
       fileName: uploadResult.fileName!,
       url: fileUrl, // ✅ URL corregida usando filePath
-      uploadedAt: new Date().toLocaleDateString('en-CA'), // Usar fecha local en formato YYYY-MM-DD
+      uploadedAt: new Date().toISOString(), // Usar ISO string para consistencia
       size: uploadResult.size!,
       type: file.type
     };

--- a/src/components/admin/AssignerManagementPage.tsx
+++ b/src/components/admin/AssignerManagementPage.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { User, AssignedIndicator, Faculty, Perspective, ProfessionalSchool, Office } from '@/lib/types';
+import { formatDateSpanish } from '@/lib/dateUtils';
 import { UserIcon } from 'lucide-react';
 import { getAssigners, getAllAssignedIndicators, getUserById, getFacultyById, getPerspectiveById, getAllFaculties, getAllProfessionalSchools, getAllOffices, getAllUsers } from '@/lib/data';
 
@@ -39,20 +40,7 @@ export default function AssignerManagementPage() {
   }, []);
   const [modalOpen, setModalOpen] = useState(false);
 
-  // Función para formatear fechas
-  const formatDate = (dateStr: string) => {
-    try {
-      const date = new Date(dateStr);
-      if (isNaN(date.getTime())) return '-';
-      return new Intl.DateTimeFormat('es-ES', {
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric'
-      }).format(date);
-    } catch (error) {
-      return '-';
-    }
-  };
+  // Using centralized date utility function
 
   // Función para determinar la variante del Badge según el estado
   const getStatusVariant = (status: string): "default" | "secondary" | "destructive" | "outline" => {
@@ -128,7 +116,7 @@ export default function AssignerManagementPage() {
         school: school?.name || '-',
         office: office?.name || 'No tiene oficina',
         jurado: juradoNombres,
-        dueDate: a.dueDate ? new Date(a.dueDate).toLocaleDateString() : '-',
+        dueDate: a.dueDate ? formatDateSpanish(a.dueDate) : '-',
         status: a.overallStatus || 'Pendiente',
       };
     }));
@@ -340,7 +328,7 @@ export default function AssignerManagementPage() {
                         <td className="px-4 py-3">{asig.faculty || 'No tiene facultad'}</td>
                         <td className="px-4 py-3">{asig.office || 'No tiene oficina'}</td>
                         <td className="px-4 py-3 max-w-[200px] truncate" title={asig.jurado}>{asig.jurado}</td>
-                        <td className="px-4 py-3">{asig.dueDate ? formatDate(asig.dueDate) : '-'}</td>
+                        <td className="px-4 py-3">{asig.dueDate ? formatDateSpanish(asig.dueDate) : '-'}</td>
                         <td className="px-4 py-3">
                           <Badge variant={getStatusVariant(asig.status)}>{asig.status}</Badge>
                         </td>

--- a/src/components/admin/grading/GradingAssignmentAccordionItem.tsx
+++ b/src/components/admin/grading/GradingAssignmentAccordionItem.tsx
@@ -13,8 +13,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { CheckCircle, AlertCircle, Clock, FileText, Paperclip, Save, Info, Users, FileCheck, ChevronDown, Eye } from 'lucide-react';
-import { format, parseISO, isPast } from 'date-fns';
-import { es } from 'date-fns/locale';
+import { formatDate, isDatePast } from '@/lib/dateUtils';
 import { cn } from '@/lib/utils';
 import { FilePreview } from '@/components/ui/file-preview';
 
@@ -131,7 +130,7 @@ export function GradingAssignmentAccordionItem({ assignment, indicator, indicato
   
   let overallStatus = assignment.overallStatus || 'Pending';
   //@ts-ignore
-  if (overallStatus === 'Pending' && assignment.assignedVerificationMethods.some(vm => vm.dueDate && isPast(new Date(vm.dueDate?.seconds * 1000)) && vm.status === 'Pending')) {
+  if (overallStatus === 'Pending' && assignment.assignedVerificationMethods.some(vm => vm.dueDate && isDatePast(vm.dueDate) && vm.status === 'Pending')) {
       overallStatus = 'Overdue';
   }
   const OverallStatusIcon = statusIcons[overallStatus] || Info;
@@ -189,7 +188,7 @@ export function GradingAssignmentAccordionItem({ assignment, indicator, indicato
               const methodInfo = getMethodInfo(method.name);
               let currentVmStatus = method.status; 
               //@ts-ignore
-              if (method.status === 'Pending' && method.dueDate && isPast(new Date(method.dueDate?.seconds * 1000))) {
+              if (method.status === 'Pending' && method.dueDate && isDatePast(method.dueDate)) {
                   currentVmStatus = 'Overdue';
               }
               const VmStatusIcon = statusIcons[currentVmStatus] || Info;

--- a/src/components/dashboard/IndicatorTable.tsx
+++ b/src/components/dashboard/IndicatorTable.tsx
@@ -9,8 +9,7 @@ import { getIndicatorById, getPerspectiveById } from '@/lib/data';
 import type { AssignedIndicator, AssignedVerificationMethod, Indicator, Perspective, VerificationStatus } from '@/lib/types';
 import { statusTranslations } from '@/lib/types'; // Import translations
 import { cn } from '@/lib/utils';
-import { format, isPast } from 'date-fns';
-import { es } from 'date-fns/locale'; // Import Spanish locale for date-fns
+import { formatDate, isDatePast } from '@/lib/dateUtils';
 import { AlertCircle, CheckCircle, Clock, Eye, FileText, Info } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -47,7 +46,7 @@ const VerificationMethodDetails: React.FC<{ vm: AssignedVerificationMethod }> = 
   console.log(vm)
   let currentStatus = vm.status;
   //@ts-ignore
-  if (vm.status === 'Pending' && vm.dueDate && isPast(new Date(vm.dueDate?.seconds * 1000))) {
+  if (vm.status === 'Pending' && vm.dueDate && isDatePast(vm.dueDate)) {
     currentStatus = 'Overdue';
   }
   const Icon = statusIcons[currentStatus] || AlertCircle;
@@ -66,36 +65,7 @@ const VerificationMethodDetails: React.FC<{ vm: AssignedVerificationMethod }> = 
       
       {
       //@ts-ignore
-      vm.dueDate && <p className="text-xs mt-1.5 text-muted-foreground">Vence: <span className="font-medium text-foreground">{(() => {
-        try {
-          const date = vm.dueDate as any;
-          if (!date) return 'Fecha no disponible';
-          
-          let dateObj: Date;
-          if (date.seconds) {
-            dateObj = new Date(date.seconds * 1000);
-          } else if (date instanceof Date) {
-            dateObj = date;
-          } else if (typeof date === 'object' && date.toDate) {
-            dateObj = date.toDate();
-          } else if (typeof date === 'number') {
-            dateObj = new Date(date);
-          } else if (typeof date === 'string') {
-            dateObj = new Date(date);
-          } else {
-            dateObj = new Date(date);
-          }
-          
-          if (isNaN(dateObj.getTime()) || dateObj.getTime() === 0) {
-            return 'Fecha no disponible';
-          }
-          
-          return format(dateObj, 'dd-MMM-yyyy', { locale: es });
-        } catch (error) {
-          console.error('Error formatting date:', error);
-          return 'Fecha no disponible';
-        }
-      })()}</span></p>
+      vm.dueDate && <p className="text-xs mt-1.5 text-muted-foreground">Vence: <span className="font-medium text-foreground">{formatDate(vm.dueDate)}</span></p>
       }
       
       {vm.submittedFile && (
@@ -105,7 +75,7 @@ const VerificationMethodDetails: React.FC<{ vm: AssignedVerificationMethod }> = 
             <span className="font-medium text-foreground">{vm.submittedFile.name}</span>
             {
               //@ts-ignore
-             vm.submittedFile.uploadedAt && <span className="text-muted-foreground text-xs block">Subido: {format(new Date(vm.dueDate?.seconds * 1000), 'dd-MMM-yyyy HH:mm:ss', { locale: es })}</span>
+             vm.submittedFile.uploadedAt && <span className="text-muted-foreground text-xs block">Subido: {formatDate(vm.submittedFile.uploadedAt, 'dd-MMM-yyyy HH:mm:ss')}</span>
             }
           </div>
           <Button variant="outline" size="sm" className="h-auto py-1 px-2 ml-auto text-xs" onClick={() => alert(`Visualizando ${vm.submittedFile?.name}`)}>
@@ -209,7 +179,7 @@ export function IndicatorTable({ assignedIndicators }: IndicatorTableProps) {
 
             let overallStatus = assignedInd.overallStatus || 'Pending';
             //@ts-ignore
-            if (overallStatus === 'Pending' && assignedInd.assignedVerificationMethods.some(vm => vm.dueDate && isPast(new Date(vm.dueDate?.seconds * 1000)) && vm.status === 'Pending')) {
+            if (overallStatus === 'Pending' && assignedInd.assignedVerificationMethods.some(vm => vm.dueDate && isDatePast(vm.dueDate) && vm.status === 'Pending')) {
                 overallStatus = 'Overdue';
             }
             const OverallStatusIcon = statusIcons[overallStatus] || AlertCircle;

--- a/src/components/layout/NotificationBell.tsx
+++ b/src/components/layout/NotificationBell.tsx
@@ -13,6 +13,7 @@ import { Bell, AlertCircle, CheckCircle, Info, XCircle, Trash2 } from 'lucide-re
 import { useAuth } from '@/hooks/useAuth';
 import { Notification } from '@/lib/types';
 import { cn } from '@/lib/utils';
+import { getRelativeTime, formatDateSpanish } from '@/lib/dateUtils';
 import { 
   markNotificationAsRead, 
   markAllNotificationsAsRead, 
@@ -89,19 +90,7 @@ export function NotificationBell() {
     }
   };
 
-  const formatDate = (date: Date) => {
-    const now = new Date();
-    const diff = now.getTime() - new Date(date).getTime();
-    const minutes = Math.floor(diff / 60000);
-    const hours = Math.floor(diff / 3600000);
-    const days = Math.floor(diff / 86400000);
-
-    if (minutes < 1) return 'Ahora';
-    if (minutes < 60) return `Hace ${minutes} min`;
-    if (hours < 24) return `Hace ${hours} h`;
-    if (days < 7) return `Hace ${days} días`;
-    return new Date(date).toLocaleDateString();
-  };
+  // Using centralized date utility function
 
   const handleNotificationClick = async (notification: Notification) => {
     // Marcar como leída
@@ -176,7 +165,7 @@ export function NotificationBell() {
                             <h5 className="font-medium text-sm">{notification.title}</h5>
                             <div className="flex items-center gap-1">
                               <span className="text-xs opacity-70">
-                                {formatDate(notification.createdAt)}
+                                {getRelativeTime(notification.createdAt)}
                               </span>
                               <Button
                                 variant="ghost"

--- a/src/components/my-assignments/AssignmentCard.tsx
+++ b/src/components/my-assignments/AssignmentCard.tsx
@@ -4,6 +4,7 @@ import type { AssignedIndicator } from '@/lib/types';
 import { Badge } from '@/components/ui/badge';
 import { Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDateSpanish } from '@/lib/dateUtils';
 
 interface AssignmentCardProps {
   assignedIndicator: AssignedIndicator;
@@ -53,7 +54,7 @@ export function AssignmentCard({ assignedIndicator, onViewDetails, onFileUpload,
     const hasOffice = officeName && !officeName.includes('Sin oficina');
     
     // Formatear fecha de vencimiento
-    const dueDate = assignedIndicator.dueDate ? new Date(assignedIndicator.dueDate).toLocaleDateString('es-ES', {
+    const dueDate = assignedIndicator.dueDate ? formatDateSpanish(assignedIndicator.dueDate, {
       year: 'numeric',
       month: 'long',
       day: 'numeric'
@@ -98,7 +99,7 @@ export function AssignmentCard({ assignedIndicator, onViewDetails, onFileUpload,
   } else {
     // Vista para usuarios normales
     const indicatorName = assignedIndicator.indicatorId || 'Indicador sin nombre';
-    const dueDate = assignedIndicator.dueDate ? new Date(assignedIndicator.dueDate).toLocaleDateString() : 'Sin fecha límite';
+    const dueDate = assignedIndicator.dueDate ? formatDateSpanish(assignedIndicator.dueDate) : 'Sin fecha límite';
     
     // Calcular progreso
     const totalMethods = assignedIndicator.assignedVerificationMethods?.length || 0;

--- a/src/components/my-assignments/AssignmentDetailsModal.tsx
+++ b/src/components/my-assignments/AssignmentDetailsModal.tsx
@@ -9,8 +9,7 @@ import { getIndicatorById, getPerspectiveById } from '@/lib/data';
 import type { AssignedIndicator, Indicator, Perspective, VerificationStatus } from '@/lib/types';
 import { statusTranslations } from '@/lib/types';
 import { cn } from '@/lib/utils';
-import { format, isPast } from 'date-fns';
-import { es } from 'date-fns/locale';
+import { formatDate, isDatePast } from '@/lib/dateUtils';
 import { AlertCircle, Briefcase, CheckCircle, Clock, FileText, Info, Paperclip, X, Eye, Edit } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -73,7 +72,7 @@ export function AssignmentDetailsModal({ indicator, isOpen, onClose }: Assignmen
 
   let overallStatus = indicator.overallStatus || 'Pending';
   //@ts-ignore
-  if (overallStatus === 'Pending' && indicator.assignedVerificationMethods.some(vm => vm.dueDate && isPast(new Date(vm.dueDate?.seconds * 1000)) && vm.status === 'Pending')) {
+  if (overallStatus === 'Pending' && indicator.assignedVerificationMethods.some(vm => vm.dueDate && isDatePast(vm.dueDate) && vm.status === 'Pending')) {
       overallStatus = 'Overdue';
   }
   const OverallStatusIcon = statusIconsModal[overallStatus] || Info;
@@ -124,7 +123,7 @@ export function AssignmentDetailsModal({ indicator, isOpen, onClose }: Assignmen
             {indicator.assignedVerificationMethods.map((vm,index) => {
               let currentVmStatus = vm.status;
               //@ts-ignore
-              if (vm.status === 'Pending' && vm.dueDate && isPast(new Date(vm.dueDate?.seconds * 1000))) {
+              if (vm.status === 'Pending' && vm.dueDate && isDatePast(vm.dueDate)) {
                 currentVmStatus = 'Overdue';
               }
               const VmStatusIcon = statusIconsModal[currentVmStatus] || Info;
@@ -139,36 +138,7 @@ export function AssignmentDetailsModal({ indicator, isOpen, onClose }: Assignmen
                   </div>
                   {vm.dueDate && (
                   <p className="text-xs text-muted-foreground">
-                    Vence: {(() => {
-                      try {
-                        const date = vm.dueDate as any;
-                        if (!date) return 'Fecha no disponible';
-                        
-                        let dateObj: Date;
-                        if (date.seconds) {
-                          dateObj = new Date(date.seconds * 1000);
-                        } else if (date instanceof Date) {
-                          dateObj = date;
-                        } else if (typeof date === 'object' && date.toDate) {
-                          dateObj = date.toDate();
-                        } else if (typeof date === 'number') {
-                          dateObj = new Date(date);
-                        } else if (typeof date === 'string') {
-                          dateObj = new Date(date);
-                        } else {
-                          dateObj = new Date(date);
-                        }
-                        
-                        if (isNaN(dateObj.getTime()) || dateObj.getTime() === 0) {
-                          return 'Fecha no disponible';
-                        }
-                        
-                        return format(dateObj, 'dd-MMM-yyyy', { locale: es });
-                      } catch (error) {
-                        console.error('Error formatting date:', error);
-                        return 'Fecha no disponible';
-                      }
-                    })()}
+                    Vence: {formatDate(vm.dueDate)}
                   </p>
                 )}
                   {vm.submittedFile && (

--- a/src/components/my-assignments/UserAssignmentCard.tsx
+++ b/src/components/my-assignments/UserAssignmentCard.tsx
@@ -7,8 +7,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Eye, UploadCloud, CheckCircle, AlertCircle, Clock, FileText, Info, Briefcase } from 'lucide-react';
-import { format, parseISO, isPast } from 'date-fns';
-import { es } from 'date-fns/locale';
+import { formatDate, isDatePast, safeParseDate } from '@/lib/dateUtils';
 import { cn } from '@/lib/utils';
 import { UserVerificationMethodItem } from './UserVerificationMethodItem';
 import { useState, useEffect } from 'react';
@@ -103,31 +102,9 @@ export function UserAssignmentCard({ assignedIndicator, onViewDetails, onFileUpl
   }
   console.log(assignedIndicator.overallStatus)
   let overallStatus = assignedIndicator.overallStatus || 'Pending';
-  //@ts-ignore
-  if (overallStatus === 'Pending' && assignedIndicator.assignedVerificationMethods.some(vm => {
-    try {
-      if (!vm.dueDate) return false;
-      let dateObj: Date;
-      const dueDate = vm.dueDate as any;
-      if (dueDate.seconds) {
-        dateObj = new Date(dueDate.seconds * 1000);
-      } else if (dueDate instanceof Date) {
-        dateObj = dueDate;
-      } else if (typeof dueDate === 'object' && dueDate.toDate) {
-        dateObj = dueDate.toDate();
-      } else if (typeof dueDate === 'number') {
-        dateObj = new Date(dueDate);
-      } else if (typeof dueDate === 'string') {
-        dateObj = new Date(dueDate);
-      } else {
-        dateObj = new Date(dueDate);
-      }
-      return !isNaN(dateObj.getTime()) && dateObj.getTime() !== 0 && isPast(dateObj) && vm.status === 'Pending';
-    } catch (error) {
-      console.error('Error checking due date:', error);
-      return false;
-    }
-  })) {
+  if (overallStatus === 'Pending' && assignedIndicator.assignedVerificationMethods.some(vm => 
+    vm.dueDate && isDatePast(vm.dueDate) && vm.status === 'Pending'
+  )) {
       overallStatus = 'Overdue';
   }
   const OverallStatusIcon = statusIcons[overallStatus] || Info;

--- a/src/components/my-assignments/UserAssignmentDetails.tsx
+++ b/src/components/my-assignments/UserAssignmentDetails.tsx
@@ -22,8 +22,7 @@ import {
   ArrowLeft
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { format } from 'date-fns';
-import { es } from 'date-fns/locale';
+import { formatDate, safeParseDate } from '@/lib/dateUtils';
 import type { AssignedIndicator, AssignedVerificationMethod, MockFile, VerificationStatus } from '@/lib/types';
 
 interface UserAssignmentDetailsProps {
@@ -107,43 +106,7 @@ export function UserAssignmentDetails({ assignment, onBack, onFileUpload }: User
     return assignment.assignedVerificationMethods.find(method => method.name === methodName);
   };
 
-  const formatDate = (date: any, formatStr: string = 'dd/MM/yyyy'): string => {
-    if (!date) return 'Fecha no disponible';
-    
-    try {
-      let dateObj: Date;
-      
-      // Manejar diferentes tipos de fechas
-      if (date.seconds) {
-        // Firestore timestamp
-        dateObj = new Date(date.seconds * 1000);
-      } else if (date instanceof Date) {
-        dateObj = date;
-      } else if (typeof date === 'object' && date.toDate) {
-        // Firestore Timestamp object
-        dateObj = date.toDate();
-      } else if (typeof date === 'number') {
-        // Timestamp numérico
-        dateObj = new Date(date);
-      } else if (typeof date === 'string') {
-        // String de fecha
-        dateObj = new Date(date);
-      } else {
-        // Intentar crear Date de cualquier otro valor
-        dateObj = new Date(date);
-      }
-      
-      // Verificar si la fecha es válida
-      if (isNaN(dateObj.getTime()) || dateObj.getTime() === 0) {
-        return 'Fecha no disponible';
-      }
-      
-      return format(dateObj, 'dd-MMM-yyyy', { locale: es });
-    } catch (error) {
-      console.error('Error formatting date:', error);
-      return 'Fecha no disponible';
-    }
-  };
+  // Using the centralized date utility function
 
   return (
     <div className="container mx-auto py-6 space-y-6">

--- a/src/components/my-assignments/UserVerificationMethodItem.tsx
+++ b/src/components/my-assignments/UserVerificationMethodItem.tsx
@@ -141,12 +141,12 @@ export function UserVerificationMethodItem({ assignedIndicatorId, verificationMe
     try {
       const methodName = verificationMethod?.name || 'Método de Verificación';
       const currentDate = new Date();
-      const fileName = `${methodName.substring(0, 4)}_${format(currentDate, 'dd-MMM-yyyy HH:mm:ss')}`;
+      const fileName = `${methodName.substring(0, 4)}_${formatDate(currentDate, 'dd-MMM-yyyy HH:mm:ss')}`;
       
                            const submittedFile = {
           name: fileName,
           url: urlInput.trim(),
-          uploadedAt: new Date().toLocaleDateString('en-CA'), // Usar fecha local en formato YYYY-MM-DD
+          uploadedAt: new Date().toISOString(), // Usar ISO string para consistencia
           size: Math.floor(Math.random() * 1000000) + 10000, // Tamaño inventado entre 10KB y 1MB
           type: 'url'
         };

--- a/src/components/my-assignments/UserVerificationMethodItem.tsx
+++ b/src/components/my-assignments/UserVerificationMethodItem.tsx
@@ -7,8 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { UploadCloud, Eye, CheckCircle, AlertCircle, Clock, FileText, Paperclip, Info, Check, X, FileUp, Edit } from 'lucide-react';
-import { format, parseISO, isPast } from 'date-fns';
-import { es } from 'date-fns/locale';
+import { formatDate, isDatePast, safeParseDate } from '@/lib/dateUtils';
 import { cn } from '@/lib/utils';
 import React, { useRef, useState, useEffect } from 'react';
 import { useToast } from '@/hooks/use-toast';
@@ -85,43 +84,7 @@ export function UserVerificationMethodItem({ assignedIndicatorId, verificationMe
     }
   }, [verificationMethod]);
 
-  const formatDate = (date: any): string => {
-    if (!date) return 'Fecha no disponible';
-    
-    try {
-      let dateObj: Date;
-      
-      // Manejar diferentes tipos de fechas
-      if (date.seconds) {
-        // Firestore timestamp
-        dateObj = new Date(date.seconds * 1000);
-      } else if (date instanceof Date) {
-        dateObj = date;
-      } else if (typeof date === 'object' && date.toDate) {
-        // Firestore Timestamp object
-        dateObj = date.toDate();
-      } else if (typeof date === 'number') {
-        // Timestamp numérico
-        dateObj = new Date(date);
-      } else if (typeof date === 'string') {
-        // String de fecha (YYYY-MM-DD o cualquier formato)
-        dateObj = new Date(date);
-      } else {
-        // Intentar crear Date de cualquier otro valor
-        dateObj = new Date(date);
-      }
-      
-      // Verificar si la fecha es válida
-      if (isNaN(dateObj.getTime()) || dateObj.getTime() === 0) {
-        return 'Fecha no disponible';
-      }
-      
-      return format(dateObj, 'dd-MMM-yyyy', { locale: es });
-    } catch (error) {
-      console.error('Error formatting date:', error);
-      return 'Fecha no disponible';
-    }
-  };
+  // Using the centralized date utility function
 
   const calculateOverallStatus = (methods: AssignedVerificationMethod[]): VerificationStatus => {
     if (methods.length === 0) return 'Pending';
@@ -135,32 +98,8 @@ export function UserVerificationMethodItem({ assignedIndicatorId, verificationMe
   };
 
   let currentStatus = localMethod.status;
-  //@ts-ignore
-  if (localMethod.status === 'Pending' && localMethod.dueDate) {
-    try {
-      let dueDateObj: Date;
-      const dueDate = localMethod.dueDate as any;
-      
-      if (dueDate.seconds) {
-        dueDateObj = new Date(dueDate.seconds * 1000);
-      } else if (dueDate instanceof Date) {
-        dueDateObj = dueDate;
-      } else if (typeof dueDate === 'object' && dueDate.toDate) {
-        dueDateObj = dueDate.toDate();
-      } else if (typeof dueDate === 'number') {
-        dueDateObj = new Date(dueDate);
-      } else if (typeof dueDate === 'string') {
-        dueDateObj = new Date(dueDate);
-      } else {
-        dueDateObj = new Date(dueDate);
-      }
-      
-      if (!isNaN(dueDateObj.getTime()) && dueDateObj.getTime() !== 0 && isPast(dueDateObj)) {
-        currentStatus = 'Overdue';
-      }
-    } catch (error) {
-      console.error('Error checking due date:', error);
-    }
+  if (localMethod.status === 'Pending' && localMethod.dueDate && isDatePast(localMethod.dueDate)) {
+    currentStatus = 'Overdue';
   }
   const StatusIcon = statusIcons[currentStatus] || Info;
 

--- a/src/components/ui/file-preview.tsx
+++ b/src/components/ui/file-preview.tsx
@@ -15,8 +15,7 @@ import {
   ExternalLink,
   FileCheck
 } from 'lucide-react';
-import { format } from 'date-fns';
-import { es } from 'date-fns/locale';
+import { formatDate } from '@/lib/dateUtils';
 import type { MockFile } from '@/lib/types';
 
 interface FilePreviewProps {
@@ -56,20 +55,7 @@ export function FilePreview({ file, isOpen, onClose, onDownload }: FilePreviewPr
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   };
 
-  const formatDate = (date: any): string => {
-    if (!date) return '';
-    
-    let dateObj: Date;
-    if (date.seconds) {
-      dateObj = new Date(date.seconds * 1000);
-    } else if (date instanceof Date) {
-      dateObj = date;
-    } else {
-      dateObj = new Date(date);
-    }
-    
-    return format(dateObj, 'dd-MMM-yyyy HH:mm:ss', { locale: es });
-  };
+  // Using centralized date utility function
 
   const getFileIcon = (fileName: string) => {
     const extension = fileName.split('.').pop()?.toLowerCase();
@@ -123,7 +109,7 @@ export function FilePreview({ file, isOpen, onClose, onDownload }: FilePreviewPr
                 <DialogDescription asChild>
                     <div className="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
                     {file.size && <span>{formatFileSize(file.size)}</span>}
-                    {file.uploadedAt && <span>Subido: {formatDate(file.uploadedAt)}</span>}
+                    {file.uploadedAt && <span>Subido: {formatDate(file.uploadedAt, 'dd-MMM-yyyy HH:mm:ss')}</span>}
                     {file.type && (
                         <Badge variant="outline" className="text-xs">{file.type}</Badge>
                     )}

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,250 @@
+import { format, parse, parseISO, isPast, isValid } from 'date-fns';
+import { es } from 'date-fns/locale';
+
+/**
+ * Utility functions for handling dates in the system
+ * Handles Spanish date formats from the database and provides consistent formatting
+ */
+
+// Spanish month names mapping
+const SPANISH_MONTHS: { [key: string]: string } = {
+  'enero': '01',
+  'febrero': '02',
+  'marzo': '03',
+  'abril': '04',
+  'mayo': '05',
+  'junio': '06',
+  'julio': '07',
+  'agosto': '08',
+  'septiembre': '09',
+  'octubre': '10',
+  'noviembre': '11',
+  'diciembre': '12',
+};
+
+/**
+ * Parses Spanish date format from database
+ * Handles formats like: "30 de agosto de 2025, 10:10:00 a.m. UTC-5"
+ */
+export function parseSpanishDate(dateString: string): Date | null {
+  if (!dateString || typeof dateString !== 'string') {
+    return null;
+  }
+
+  try {
+    // Remove UTC timezone info and clean the string
+    const cleanedDate = dateString.replace(/\s*UTC[+-]\d+\s*$/, '').trim();
+    
+    // Pattern to match Spanish date format: "30 de agosto de 2025, 10:10:00 a.m."
+    const spanishDatePattern = /^(\d{1,2})\s+de\s+(\w+)\s+de\s+(\d{4}),\s+(\d{1,2}):(\d{2}):(\d{2})\s+(a\.m\.|p\.m\.)$/i;
+    const match = cleanedDate.match(spanishDatePattern);
+    
+    if (match) {
+      const [, day, monthName, year, hour, minute, second, period] = match;
+      
+      // Convert Spanish month name to number
+      const monthNum = SPANISH_MONTHS[monthName.toLowerCase()];
+      if (!monthNum) {
+        console.warn(`Unknown Spanish month: ${monthName}`);
+        return null;
+      }
+      
+      // Convert 12-hour format to 24-hour format
+      let hour24 = parseInt(hour, 10);
+      const isPM = period.toLowerCase().includes('p.m.');
+      
+      if (isPM && hour24 !== 12) {
+        hour24 += 12;
+      } else if (!isPM && hour24 === 12) {
+        hour24 = 0;
+      }
+      
+      // Create ISO string and parse it
+      const isoString = `${year}-${monthNum}-${day.padStart(2, '0')}T${hour24.toString().padStart(2, '0')}:${minute}:${second}`;
+      const parsedDate = parseISO(isoString);
+      
+      if (isValid(parsedDate)) {
+        return parsedDate;
+      }
+    }
+    
+    // Fallback: try to parse as regular date
+    const fallbackDate = new Date(dateString);
+    if (isValid(fallbackDate) && !isNaN(fallbackDate.getTime())) {
+      return fallbackDate;
+    }
+    
+    return null;
+  } catch (error) {
+    console.error('Error parsing Spanish date:', error, 'Date string:', dateString);
+    return null;
+  }
+}
+
+/**
+ * Safely parses any date format and returns a Date object
+ */
+export function safeParseDate(date: any): Date | null {
+  if (!date) return null;
+  
+  try {
+    let dateObj: Date | null = null;
+    
+    // Handle Firestore timestamp
+    if (date.seconds) {
+      dateObj = new Date(date.seconds * 1000);
+    } 
+    // Handle Date objects
+    else if (date instanceof Date) {
+      dateObj = date;
+    } 
+    // Handle Firestore Timestamp objects
+    else if (typeof date === 'object' && date.toDate) {
+      dateObj = date.toDate();
+    } 
+    // Handle numeric timestamps
+    else if (typeof date === 'number') {
+      dateObj = new Date(date);
+    } 
+    // Handle string dates
+    else if (typeof date === 'string') {
+      // First try to parse as Spanish date
+      dateObj = parseSpanishDate(date);
+      
+      // If that fails, try regular parsing
+      if (!dateObj) {
+        dateObj = new Date(date);
+        if (!isValid(dateObj) || isNaN(dateObj.getTime())) {
+          dateObj = null;
+        }
+      }
+    } 
+    // Handle other types
+    else {
+      dateObj = new Date(date);
+      if (!isValid(dateObj) || isNaN(dateObj.getTime())) {
+        dateObj = null;
+      }
+    }
+    
+    // Final validation
+    if (dateObj && isValid(dateObj) && !isNaN(dateObj.getTime()) && dateObj.getTime() !== 0) {
+      return dateObj;
+    }
+    
+    return null;
+  } catch (error) {
+    console.error('Error in safeParseDate:', error, 'Input:', date);
+    return null;
+  }
+}
+
+/**
+ * Formats a date with consistent Spanish formatting
+ */
+export function formatDate(date: any, formatStr: string = 'dd-MMM-yyyy'): string {
+  const parsedDate = safeParseDate(date);
+  
+  if (!parsedDate) {
+    return 'Fecha no disponible';
+  }
+  
+  try {
+    return format(parsedDate, formatStr, { locale: es });
+  } catch (error) {
+    console.error('Error formatting date:', error);
+    return 'Fecha no disponible';
+  }
+}
+
+/**
+ * Formats a date for display in Spanish locale
+ */
+export function formatDateSpanish(date: any, options?: Intl.DateTimeFormatOptions): string {
+  const parsedDate = safeParseDate(date);
+  
+  if (!parsedDate) {
+    return 'Fecha no disponible';
+  }
+  
+  try {
+    const defaultOptions: Intl.DateTimeFormatOptions = {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      ...options
+    };
+    
+    return new Intl.DateTimeFormat('es-ES', defaultOptions).format(parsedDate);
+  } catch (error) {
+    console.error('Error formatting date with Intl:', error);
+    return formatDate(date);
+  }
+}
+
+/**
+ * Checks if a date is in the past
+ */
+export function isDatePast(date: any): boolean {
+  const parsedDate = safeParseDate(date);
+  if (!parsedDate) return false;
+  
+  try {
+    return isPast(parsedDate);
+  } catch (error) {
+    console.error('Error checking if date is past:', error);
+    return false;
+  }
+}
+
+/**
+ * Formats file size in human readable format
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 Bytes';
+  
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+/**
+ * Gets a relative time string (e.g., "hace 2 días")
+ */
+export function getRelativeTime(date: any): string {
+  const parsedDate = safeParseDate(date);
+  
+  if (!parsedDate) {
+    return 'Fecha desconocida';
+  }
+  
+  const now = new Date();
+  const diffInMs = now.getTime() - parsedDate.getTime();
+  const diffInMinutes = Math.floor(diffInMs / (1000 * 60));
+  const diffInHours = Math.floor(diffInMs / (1000 * 60 * 60));
+  const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
+  
+  if (diffInMinutes < 1) {
+    return 'Ahora mismo';
+  } else if (diffInMinutes < 60) {
+    return `Hace ${diffInMinutes} minuto${diffInMinutes !== 1 ? 's' : ''}`;
+  } else if (diffInHours < 24) {
+    return `Hace ${diffInHours} hora${diffInHours !== 1 ? 's' : ''}`;
+  } else if (diffInDays < 30) {
+    return `Hace ${diffInDays} día${diffInDays !== 1 ? 's' : ''}`;
+  } else {
+    return formatDate(parsedDate, 'dd/MM/yyyy');
+  }
+}
+
+export default {
+  parseSpanishDate,
+  safeParseDate,
+  formatDate,
+  formatDateSpanish,
+  isDatePast,
+  formatFileSize,
+  getRelativeTime,
+};

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,5 +1,5 @@
 import { format, parse, parseISO, isPast, isValid } from 'date-fns';
-import { es } from 'date-fns/locale';
+import { es } from 'date-fns/locale/es';
 
 /**
  * Utility functions for handling dates in the system


### PR DESCRIPTION
Fix "Invalid Date" errors by centralizing date parsing and formatting for Spanish locale.

The system was failing to parse dates stored in Spanish format (e.g., "30 de agosto de 2025, 10:10:00 a.m. UTC-5"), leading to "Invalid Date" displays. This PR introduces a robust `dateUtils.ts` to correctly parse these formats and provides consistent Spanish formatting across the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bd2f47f-b526-42e8-adc0-faad5f09ac27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8bd2f47f-b526-42e8-adc0-faad5f09ac27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

